### PR TITLE
Add support for Gradle's Configuration Cache

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,6 +1,10 @@
 name: Gradle check
 
-on: [push]
+on:
+  push:
+  pull_request:
+    branches:
+      - main
 
 jobs:
   gradle-build:

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ pluginBundle {
 }
 
 dependencies {
+    compileOnly("javax.inject:javax.inject:1")
     testImplementation gradleTestKit()
 
     testImplementation(platform("org.junit:junit-bom:5.9.1"))

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,3 @@
-buildscript {
-    repositories {
-        gradlePluginPortal()
-        mavenCentral()
-    }
-}
-
 plugins {
     id 'java-gradle-plugin'
     id 'maven-publish'
@@ -38,10 +31,6 @@ pluginBundle {
             displayName = 'Maestro tests plugin'
         }
     }
-}
-
-repositories {
-    mavenCentral()
 }
 
 dependencies {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,12 +1,23 @@
+import org.gradle.api.initialization.resolve.RepositoriesMode
+
 pluginManagement {
     repositories {
         mavenLocal()
+        mavenCentral()
         gradlePluginPortal()
     }
 }
 
 plugins {
     id "com.atkinsondev.object-store-cache" version "1.2.0"
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
 }
 
 boolean isCI = Boolean.valueOf(System.getenv("GITHUB_ACTIONS"))

--- a/src/main/kotlin/com/atkinsondev/maestro/MaestroTest.kt
+++ b/src/main/kotlin/com/atkinsondev/maestro/MaestroTest.kt
@@ -5,9 +5,13 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
+import org.gradle.process.ExecOperations
 import java.io.File
+import javax.inject.Inject
 
-abstract class MaestroTest : DefaultTask() {
+abstract class MaestroTest @Inject constructor(
+    private val execOperations: ExecOperations,
+) : DefaultTask() {
     @get:Input
     abstract val flowsDir: Property<File>
 
@@ -33,7 +37,7 @@ abstract class MaestroTest : DefaultTask() {
             project.logger.info("Found ${flowFiles?.size ?: 0} flow files in directory ${flowsDir.absolutePath}")
 
             flowFiles?.forEach { flowFile ->
-                project.exec {
+                execOperations.exec {
                     it.workingDir = flowsDir
 
                     val maestroCommandLine = listOf(maestroExecutable, "test", flowFile.name)
@@ -49,7 +53,7 @@ abstract class MaestroTest : DefaultTask() {
             if (screenshotFlowFile != null) {
                 project.logger.info("Maestro tests failed, capturing screenshot with flow file ${screenshotFlowFile.absolutePath}")
 
-                project.exec {
+                execOperations.exec {
                     it.setCommandLine(maestroExecutable, "test", screenshotFlowFile.absolutePath)
                 }
             }

--- a/src/main/kotlin/com/atkinsondev/maestro/MaestroTest.kt
+++ b/src/main/kotlin/com/atkinsondev/maestro/MaestroTest.kt
@@ -1,6 +1,8 @@
 package com.atkinsondev.maestro
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
@@ -13,11 +15,11 @@ abstract class MaestroTest @Inject constructor(
     private val execOperations: ExecOperations,
 ) : DefaultTask() {
     @get:Input
-    abstract val flowsDir: Property<File>
+    abstract val flowsDir: DirectoryProperty
 
     @get:Input
     @get:Optional
-    abstract val screenshotFlowFile: Property<File>
+    abstract val screenshotFlowFile: RegularFileProperty
 
     @get:Input
     abstract val maestroExecutable: Property<String>
@@ -28,7 +30,7 @@ abstract class MaestroTest @Inject constructor(
 
     @TaskAction
     fun runTests() {
-        val flowsDir = flowsDir.get()
+        val flowsDir = flowsDir.get().asFile
         val maestroExecutable = maestroExecutable.get()
 
         try {
@@ -48,7 +50,7 @@ abstract class MaestroTest @Inject constructor(
                 }
             }
         } catch (e: Exception) {
-            val screenshotFlowFile = screenshotFlowFile.orNull
+            val screenshotFlowFile = screenshotFlowFile.asFile.orNull
 
             if (screenshotFlowFile != null) {
                 logger.info("Maestro tests failed, capturing screenshot with flow file ${screenshotFlowFile.absolutePath}")

--- a/src/main/kotlin/com/atkinsondev/maestro/MaestroTest.kt
+++ b/src/main/kotlin/com/atkinsondev/maestro/MaestroTest.kt
@@ -34,7 +34,7 @@ abstract class MaestroTest @Inject constructor(
         try {
             val flowFiles = flowsDir.listFiles()?.filter { it.isFile }
 
-            project.logger.info("Found ${flowFiles?.size ?: 0} flow files in directory ${flowsDir.absolutePath}")
+            logger.info("Found ${flowFiles?.size ?: 0} flow files in directory ${flowsDir.absolutePath}")
 
             flowFiles?.forEach { flowFile ->
                 execOperations.exec {
@@ -42,7 +42,7 @@ abstract class MaestroTest @Inject constructor(
 
                     val maestroCommandLine = listOf(maestroExecutable, "test", flowFile.name)
 
-                    project.logger.info("Running Maestro command ${maestroCommandLine.joinToString(" ")}")
+                    logger.info("Running Maestro command ${maestroCommandLine.joinToString(" ")}")
 
                     it.commandLine = maestroCommandLine
                 }
@@ -51,7 +51,7 @@ abstract class MaestroTest @Inject constructor(
             val screenshotFlowFile = screenshotFlowFile.orNull
 
             if (screenshotFlowFile != null) {
-                project.logger.info("Maestro tests failed, capturing screenshot with flow file ${screenshotFlowFile.absolutePath}")
+                logger.info("Maestro tests failed, capturing screenshot with flow file ${screenshotFlowFile.absolutePath}")
 
                 execOperations.exec {
                     it.setCommandLine(maestroExecutable, "test", screenshotFlowFile.absolutePath)

--- a/src/test/kotlin/com/atkinsondev/maestro/MaestroPluginCrossVersionTest.kt
+++ b/src/test/kotlin/com/atkinsondev/maestro/MaestroPluginCrossVersionTest.kt
@@ -1,6 +1,7 @@
 package com.atkinsondev.maestro
 
 import org.gradle.testkit.runner.GradleRunner
+import org.gradle.util.GradleVersion
 import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -32,9 +33,15 @@ class MaestroPluginCrossVersionTest {
 
         File(projectRootDirPath.toFile(), "build.gradle").writeText(buildFileContents)
 
+        // Configuration Cache was introduced in Gradle 6.6, don't try to enable it on older versions.
+        val arguments = arrayListOf("maestroTest", "--info", "--stacktrace")
+        if (GradleVersion.version(gradleVersion) >= GradleVersion.version("6.6")) {
+            arguments.add("--configuration-cache")
+        }
+
         val buildResult = GradleRunner.create()
             .withProjectDir(projectRootDirPath.toFile())
-            .withArguments("maestroTest", "--info", "--stacktrace")
+            .withArguments(arguments)
             .withGradleVersion(gradleVersion)
             .withPluginClasspath()
             .build()

--- a/src/test/kotlin/com/atkinsondev/maestro/MaestroPluginTest.kt
+++ b/src/test/kotlin/com/atkinsondev/maestro/MaestroPluginTest.kt
@@ -32,7 +32,7 @@ class MaestroPluginTest {
 
         val buildResult = GradleRunner.create()
             .withProjectDir(projectRootDirPath.toFile())
-            .withArguments("maestroTest", "--info", "--stacktrace")
+            .withArguments("maestroTest", "--info", "--stacktrace", "--configuration-cache")
             .withPluginClasspath()
             .build()
 
@@ -69,7 +69,7 @@ class MaestroPluginTest {
 
         val buildResult = GradleRunner.create()
             .withProjectDir(projectRootDirPath.toFile())
-            .withArguments("maestroTest", "--info", "--stacktrace")
+            .withArguments("maestroTest", "--info", "--stacktrace", "--configuration-cache")
             .withPluginClasspath()
             .buildAndFail()
 


### PR DESCRIPTION
This PR contains some minor refactors to the `MaestroTest` task to support [Configuration Cache](https://docs.gradle.org/current/userguide/configuration_cache.html) as well as tweaks to the test suite to prevent regressions on that front.

Also tweaks repository declarations to prefer Maven Central as much as possible and avoid being routed to the flaky JCenter via Gradle Plugin Portal.
